### PR TITLE
Created .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,36 @@
+# Sources
+*.c     text diff=c
+*.cc    text diff=cpp
+*.cxx   text diff=cpp
+*.cpp   text diff=cpp
+*.c++   text diff=cpp
+*.hpp   text diff=cpp
+*.h     text diff=c
+*.h++   text diff=cpp
+*.hh    text diff=cpp
+
+# Compiled Object files
+*.slo   binary
+*.lo    binary
+*.o     binary
+*.obj   binary
+
+# Precompiled Headers
+*.gch   binary
+*.pch   binary
+
+# Compiled Dynamic libraries
+*.so    binary
+*.dylib binary
+*.dll   binary
+
+# Compiled Static libraries
+*.lai   binary
+*.la    binary
+*.a     binary
+*.lib   binary
+
+# Executables
+*.exe   binary
+*.out   binary
+*.app   binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,13 +1,15 @@
+* linguist-vendored
+
 # Sources
-*.c     text diff=c
-*.cc    text diff=cpp
-*.cxx   text diff=cpp
-*.cpp   text diff=cpp
-*.c++   text diff=cpp
-*.hpp   text diff=cpp
-*.h     text diff=c
-*.h++   text diff=cpp
-*.hh    text diff=cpp
+*.c     text diff=c linguist-vendored=false
+*.cc    text diff=cpp linguist-vendored=false
+*.cxx   text diff=cpp linguist-vendored=false
+*.cpp   text diff=cpp linguist-vendored=false
+*.c++   text diff=cpp linguist-vendored=false
+*.hpp   text diff=cpp linguist-vendored=false
+*.h     text diff=c linguist-vendored=false
+*.h++   text diff=cpp linguist-vendored=false
+*.hh    text diff=cpp linguist-vendored=false
 
 # Compiled Object files
 *.slo   binary


### PR DESCRIPTION
Allows GitHub to accurately list this as a C++ project:
![image](https://user-images.githubusercontent.com/1276140/59864983-f5643880-9355-11e9-9fc3-f5b4c5ba04fb.png)

instead of shell scripts:
![image](https://user-images.githubusercontent.com/1276140/59865003-02812780-9356-11e9-9d0c-029cf59d01d3.png)