### PR TITLE
Add algorithm header to resolve std::max reference

### DIFF
--- a/libheif/heif_encoder_aom.cc
+++ b/libheif/heif_encoder_aom.cc
@@ -35,7 +35,7 @@
 #include <aom/aom_encoder.h>
 #include <aom/aomcx.h>
 
-
+#include <algorithm>
 #include <iostream>  // TODO: remove me
 
 


### PR DESCRIPTION
Windows builds of Imagick were failing with the following error messages:
```
1>c:\php-sdk\imagemagick-windows\libheif\libheif\heif_encoder_aom.cc(524): error C3861: 'max': identifier not found
1>c:\php-sdk\imagemagick-windows\libheif\libheif\heif_encoder_aom.cc(525): error C2039: 'max': is not a member of 'std'
1>c:\php-sdk\imagemagick-windows\libheif\libheif\heif_encoder_aom.cc(525): error C3861: 'max': identifier not found
```
Including the `<algorithm>` stdlib header resolved the library build issue and allowed for windows Imagick builds to complete successfully.